### PR TITLE
implement loadbalancerIP in the livekit-server helm chart

### DIFF
--- a/charts/livekit-server/templates/turnloadbalancer.yaml
+++ b/charts/livekit-server/templates/turnloadbalancer.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   type: {{ default "LoadBalancer" .Values.livekit.turn.serviceType }}
   {{- if and (eq .Values.livekit.turn.serviceType "LoadBalancer") (not (empty .Values.livekit.turn.service.loadBalancerIP)) }}
-  loadBalancerIP: { { .Values.service.loadBalancerIP }}
+  loadBalancerIP: { { .Values.turnLoadbalancer.loadBalancerIP }}
   {{- end }}
   ports:
     - port: 443

--- a/charts/livekit-server/templates/turnloadbalancer.yaml
+++ b/charts/livekit-server/templates/turnloadbalancer.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ default "LoadBalancer" .Values.livekit.turn.serviceType }}
+  {{ - if and (eq .Values.livekit.turn.serviceType "LoadBalancer") (not (empty .Values.livekit.turn.service.loadBalancerIP)) }}
+  loadBalancerIP: { { .Values.service.loadBalancerIP }}
+  {{ - end }}
   ports:
     - port: 443
       targetPort: {{ .Values.livekit.turn.tls_port }}

--- a/charts/livekit-server/templates/turnloadbalancer.yaml
+++ b/charts/livekit-server/templates/turnloadbalancer.yaml
@@ -11,9 +11,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ default "LoadBalancer" .Values.livekit.turn.serviceType }}
-  {{ - if and (eq .Values.livekit.turn.serviceType "LoadBalancer") (not (empty .Values.livekit.turn.service.loadBalancerIP)) }}
+  {{- if and (eq .Values.livekit.turn.serviceType "LoadBalancer") (not (empty .Values.livekit.turn.service.loadBalancerIP)) }}
   loadBalancerIP: { { .Values.service.loadBalancerIP }}
-  {{ - end }}
+  {{- end }}
   ports:
     - port: 443
       targetPort: {{ .Values.livekit.turn.tls_port }}

--- a/charts/livekit-server/templates/turnloadbalancer.yaml
+++ b/charts/livekit-server/templates/turnloadbalancer.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 spec:
   type: {{ default "LoadBalancer" .Values.livekit.turn.serviceType }}
-  {{- if and (eq .Values.livekit.turn.serviceType "LoadBalancer") (not (empty .Values.livekit.turnLoadbalancer.loadBalancerIP)) }}
+  {{- if and (eq .Values.livekit.turn.serviceType "LoadBalancer") (not (empty .Values.turnLoadbalancer.loadBalancerIP)) }}
   loadBalancerIP: { { .Values.turnLoadbalancer.loadBalancerIP }}
   {{- end }}
   ports:

--- a/charts/livekit-server/templates/turnloadbalancer.yaml
+++ b/charts/livekit-server/templates/turnloadbalancer.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 spec:
   type: {{ default "LoadBalancer" .Values.livekit.turn.serviceType }}
-  {{- if and (eq .Values.livekit.turn.serviceType "LoadBalancer") (not (empty .Values.livekit.turn.service.loadBalancerIP)) }}
+  {{- if and (eq .Values.livekit.turn.serviceType "LoadBalancer") (not (empty .Values.livekit.turnLoadbalancer.loadBalancerIP)) }}
   loadBalancerIP: { { .Values.turnLoadbalancer.loadBalancerIP }}
   {{- end }}
   ports:

--- a/charts/livekit-server/values.yaml
+++ b/charts/livekit-server/values.yaml
@@ -70,6 +70,7 @@ loadBalancer:
 
 turnLoadbalancer:
   enable: true
+  loadBalancerIP: ""
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## What does this PR do?

reserve a static IP for LB as it’s changing when the whole application starts so we have to update the DNS everytime.
But this annotation [networking.gke.io/load-balancer-ip-addresses](http://networking.gke.io/load-balancer-ip-addresses) is supported for version 1.29 and later. but our’s is 1.26.15-gke.1090000 and other parameter which we can use is spec.loadBalancerIP but this is not supported with the respective application helm chart so we are doing the changes to include that

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [ ] Enhancement

Which introduces
- [ ] Breaking changes
- [ ] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

xxx

## Screenshots (if appropriate)

xxx

## Loom Video (if appropriate)

xxx

## Any Security implications

xxx
