### PR TITLE
chore: update thanos and os-shell images to use FF ghcr.io registry w…

### DIFF
--- a/charts/thanos/charts/minio/values.yaml
+++ b/charts/thanos/charts/minio/values.yaml
@@ -59,8 +59,8 @@ extraDeploy: []
 ## @param image.debug Specify if debug logs should be enabled
 ##
 image:
-  registry: docker.io
-  repository: bitnami/minio
+  registry: ghcr.io
+  repository: firefliesai/bitnami/minio
   tag: 2023.12.23-debian-11-r3
   digest: ""
   ## Specify a imagePullPolicy
@@ -88,7 +88,7 @@ image:
 ##
 clientImage:
   registry: docker.io
-  repository: bitnami/minio-client
+  repository: firefliesai/bitnami/minio-client
   tag: 2023.12.29-debian-11-r1
   digest: ""
 ## @param mode MinIO&reg; server mode (`standalone` or `distributed`)
@@ -981,8 +981,8 @@ volumePermissions:
   ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
-    registry: docker.io
-    repository: bitnami/os-shell
+    registry: ghcr.io
+    repository: firefliesai/bitnami/os-shell
     tag: 11-debian-11-r93
     digest: ""
     pullPolicy: IfNotPresent

--- a/charts/thanos/charts/minio/values.yaml
+++ b/charts/thanos/charts/minio/values.yaml
@@ -75,7 +75,8 @@ image:
   ## pullSecrets:
   ##   - myRegistryKeySecretName
   ##
-  pullSecrets: []
+  pullSecrets:
+    - regsec
   ## Set to true if you would like to see extra information on logs
   ##
   debug: false
@@ -87,7 +88,7 @@ image:
 ## @param clientImage.digest MinIO&reg; Client image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ##
 clientImage:
-  registry: docker.io
+  registry: ghcr.io
   repository: firefliesai/bitnami/minio-client
   tag: 2023.12.29-debian-11-r1
   digest: ""
@@ -993,7 +994,8 @@ volumePermissions:
     ## pullSecrets:
     ##   - myRegistryKeySecretName
     ##
-    pullSecrets: []
+    pullSecrets:
+      - regsec
   ## Init container' resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -57,7 +57,7 @@ extraDeploy: []
 image:
   registry: ghcr.io
   repository: firefliesai/bitnami/thanos
-  tag: 0.39.2-debian-12-r2
+  tag: 0.34.0-debian-11-r3
   digest: ""
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -4823,7 +4823,7 @@ volumePermissions:
   image:
     registry: ghcr.io
     repository: firefliesai/bitnami/os-shell
-    tag: 12-debian-12-r16
+    tag: 11-debian-11-r96
     digest: ""
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -55,9 +55,9 @@ extraDeploy: []
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ##
 image:
-  registry: docker.io
-  repository: bitnami/thanos
-  tag: 0.34.0-debian-11-r3
+  registry: ghcr.io
+  repository: firefliesai/bitnami/thanos
+  tag: 0.39.2-debian-12-r2
   digest: ""
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -70,7 +70,8 @@ image:
   ## pullSecrets:
   ##   - myRegistryKeySecretName
   ##
-  pullSecrets: []
+  pullSecrets:
+    - regsec
 ## @param objstoreConfig The [objstore configuration](https://thanos.io/tip/thanos/storage.md/)
 ## Specify content for objstore.yml
 ##
@@ -4820,9 +4821,9 @@ volumePermissions:
   ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
-    registry: docker.io
-    repository: bitnami/os-shell
-    tag: 11-debian-11-r96
+    registry: ghcr.io
+    repository: firefliesai/bitnami/os-shell
+    tag: 12-debian-12-r16
     digest: ""
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -4835,7 +4836,8 @@ volumePermissions:
     ## pullSecrets:
     ##   - myRegistryKeySecretName
     ##
-    pullSecrets: []
+    pullSecrets:
+      - regsec
 
 ## @section MinIO&reg; chart parameters
 ## @extra minio For full list of MinIO&reg; values configurations please refere [here](https://github.com/bitnami/charts/tree/main/bitnami/minio)


### PR DESCRIPTION
…ith newer versions

## What does this PR do?

https://firefliesapp.slack.com/archives/CPQCRMTU4/p1756130631515529?thread_ts=1753454933.641169&cid=CPQCRMTU4

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [x] Enhancement

Which introduces
- [x] Breaking changes - possibly
- [ ] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

Thanos ⚠️ Breaking Changes Summary
v0.34.0 → v0.39.2 Major Breaking Changes:
Query Frontend Metrics (v0.34.0)
Added tenant label to exported metrics
Impact: Custom dashboard queries may break due to the new label dimension
Store Sync Block Duration (v0.34.0)
Default changed from 3m to 15m
Impact: Block synchronization will happen less frequently by default
Query Pushdown Removal (v0.34.0)
Experimental query pushdown feature completely removed
Impact: If you were using this experimental feature, it's no longer available
Compact Downsample Metrics (v0.35.0)
Replaced "group" with "resolution" in compact downsample metrics
Impact: Monitoring dashboards tracking compaction metrics need updates
Query Stats Protocol (v0.36.0)
Changed protobuf of QueryAPI for distributed mode
Impact: If using query.mode=distributed, update clients before servers
GRPC Middleware Metrics (v0.36.0)
grpc_client_handling_seconds and grpc_server_handling_seconds now use native histograms
Impact: PromQL expressions need updates if native histogram scraping is enabled
Store gRPC Info Function Removal (v0.37.0)
Removed deprecated Store gRPC Info function
Impact: Any code depending on this function will break
Query/Ruler Endpoint Flags (v0.38.0)
Deprecated --store.sd-file and --store.sd-interval
Removed legacy endpoint flags: --store, --metadata, --rule, --exemplar
Impact: Configuration files need flag updates
Receive Legacy TSDB Migration (v0.39.0)
Removed migration from legacy-TSDB to multi-TSDB
Impact: Must be running version >0.13 before upgrading

## Screenshots (if appropriate)

xxx

## Loom Video (if appropriate)

xxx

## Any Security implications

xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched container image registry from docker.io to ghcr.io for Thanos, MinIO, MinIO client and helper/init images to improve reliability.
  * Updated image repositories to vendor-maintained locations while preserving existing tags and digests.
  * Added image pull secret configuration (regsec) for authenticated pulls; ensure the secret exists in target namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->