### PR TITLE
chore: bump thanos chart version to 13.0.1

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,9 +2,9 @@ annotations:
   category: Analytics
   images: |
     - name: os-shell
-      image: docker.io/bitnami/os-shell:11-debian-11-r96
+      image: ghcr.io/firefliesai/bitnami/os-shell:11-debian-11-r96
     - name: thanos
-      image: docker.io/bitnami/thanos:0.34.0-debian-11-r3
+      image: ghcr.io/firefliesai/bitnami/thanos:0.34.0-debian-11-r3
   licenses: Apache-2.0
 apiVersion: v2
 appVersion: 0.34.0

--- a/charts/thanos/charts/minio/Chart.yaml
+++ b/charts/thanos/charts/minio/Chart.yaml
@@ -2,11 +2,11 @@ annotations:
   category: Infrastructure
   images: |
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2023.12.29-debian-11-r1
+      image: ghcr.io/firefliesai/bitnami/minio-client:2023.12.29-debian-11-r1
     - name: minio
-      image: docker.io/bitnami/minio:2023.12.23-debian-11-r3
+      image: ghcr.io/firefliesai/bitnami/minio:2023.12.23-debian-11-r3
     - name: os-shell
-      image: docker.io/bitnami/os-shell:11-debian-11-r93
+      image: ghcr.io/firefliesai/bitnami/os-shell:11-debian-11-r93
   licenses: Apache-2.0
 apiVersion: v2
 appVersion: 2023.12.23


### PR DESCRIPTION
## What does this PR do?

xxx

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [x] Enhancement

Which introduces
- [ ] Breaking changes
- [x] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

xxx

## Screenshots (if appropriate)

xxx

## Loom Video (if appropriate)

xxx

## Any Security implications

xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated container image sources to the GitHub Container Registry (ghcr.io) for several packaged components.
  - Bumped the Helm chart version to 13.0.1. No functional, dependency, configuration, or behavior changes; existing deployments and upgrades remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->