### PR TITLE
chore: bump Redis chart version to 18.19.6 and update redis-exporter …

### DIFF
--- a/charts/redis-18.19.2/Chart.yaml
+++ b/charts/redis-18.19.2/Chart.yaml
@@ -36,4 +36,4 @@ name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
 - https://github.com/firefliesai/public-helm-charts
-version: 18.19.5
+version: 18.19.6

--- a/charts/redis-18.19.2/values.yaml
+++ b/charts/redis-18.19.2/values.yaml
@@ -1608,7 +1608,7 @@ metrics:
   image:
     registry: ghcr.io
     repository: firefliesai/bitnamilegacy/redis-exporter
-    tag: 1.58.0-debian-12-r4
+    tag: 1.58.0-debian-12-r6
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
…image tag

## What does this PR do?

xxx

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [ ] Enhancement

Which introduces
- [ ] Breaking changes
- [ ] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

xxx

## Screenshots (if appropriate)

xxx

## Loom Video (if appropriate)

xxx

## Any Security implications

xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped Redis Helm chart version to 18.19.6 for a patch release.
  - Updated the metrics exporter image to 1.58.0-debian-12-r6.
  - Deployments using this chart will automatically pull the newer metrics image on upgrade.
  - No user-facing feature changes; operational behavior remains the same aside from the updated metrics component.
  - Recommended to upgrade to receive the latest patch-level improvements in the metrics container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->