### PR TITLE
chore: update image repositories from bitnami to bitnamilegacy in Red…

### DIFF
--- a/charts/redis-20.0.2/Chart.yaml
+++ b/charts/redis-20.0.2/Chart.yaml
@@ -2,15 +2,15 @@ annotations:
   category: Database
   images: |
     - name: kubectl
-      image: ghcr.io/firefliesai/bitnami/kubectl:1.31.0-debian-12-r0
+      image: ghcr.io/firefliesai/bitnamilegacy/kubectl:1.31.0-debian-12-r0
     - name: os-shell
-      image: ghcr.io/firefliesai/bitnami/os-shell:12-debian-12-r18
+      image: ghcr.io/firefliesai/bitnamilegacy/os-shell:12-debian-12-r18
     - name: redis
       image: ghcr.io/firefliesai/bitnamilegacy/redis:7.4.0-debian-12-r1
     - name: redis-exporter
       image: ghcr.io/firefliesai/bitnamilegacy/redis-exporter:1.62.0-debian-12-r3
     - name: redis-sentinel
-      image: ghcr.io/firefliesai/bitnami/redis-sentinel:7.4.0-debian-12-r0
+      image: ghcr.io/firefliesai/bitnamilegacy/redis-sentinel:7.4.0-debian-12-r0
   licenses: Apache-2.0
 apiVersion: v2
 appVersion: 7.4.0

--- a/charts/redis-20.0.2/Chart.yaml
+++ b/charts/redis-20.0.2/Chart.yaml
@@ -36,4 +36,4 @@ name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
 - https://github.com/firefliesai/public-helm-charts
-version: 20.0.5
+version: 20.0.6

--- a/charts/redis-20.0.2/values.yaml
+++ b/charts/redis-20.0.2/values.yaml
@@ -101,7 +101,7 @@ diagnosticMode:
 ##
 image:
   registry: ghcr.io
-  repository: firefliesai/bitnami/redis
+  repository: firefliesai/bitnamilegacy/redis
   tag: 7.4.0-debian-12-r1
   digest: ""
   ## Specify a imagePullPolicy
@@ -1140,7 +1140,7 @@ sentinel:
   ##
   image:
     registry: ghcr.io
-    repository: firefliesai/bitnami/redis-sentinel
+    repository: firefliesai/bitnamilegacy/redis-sentinel
     tag: 7.4.0-debian-12-r0
     digest: ""
     ## Specify a imagePullPolicy
@@ -2065,7 +2065,7 @@ volumePermissions:
   ##
   image:
     registry: ghcr.io
-    repository: firefliesai/bitnami/os-shell
+    repository: firefliesai/bitnamilegacy/os-shell
     tag: 12-debian-12-r27
     digest: ""
     pullPolicy: IfNotPresent
@@ -2122,7 +2122,7 @@ kubectl:
   ##
   image:
     registry: ghcr.io
-    repository: firefliesai/bitnami/kubectl
+    repository: firefliesai/bitnamilegacy/kubectl
     tag: 1.31.0-debian-12-r0
     digest: ""
     ## Specify a imagePullPolicy
@@ -2193,7 +2193,7 @@ sysctl:
   ##
   image:
     registry: ghcr.io
-    repository: firefliesai/bitnami/os-shell
+    repository: firefliesai/bitnamilegacy/os-shell
     tag: 12-debian-12-r27
     digest: ""
     pullPolicy: IfNotPresent


### PR DESCRIPTION
…is chart

## What does this PR do?

xxx

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [ ] Enhancement

Which introduces
- [ ] Breaking changes
- [ ] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

xxx

## Screenshots (if appropriate)

xxx

## Loom Video (if appropriate)

xxx

## Any Security implications

xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped Redis Helm chart to version 20.0.6.
  - Switched container image repositories from Bitnami to Bitnami Legacy for Redis, Sentinel, kubectl, and OS shell. Redis Exporter remains unchanged.
  - Image tags and pull policies are unchanged to maintain consistent behavior.
  - No functional changes expected; existing deployments should continue operating normally.
  - Improves consistency across images used by the chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->