### PR TITLE
chore: disable default ExternalSecret creation for registry pull secr…

### DIFF
--- a/charts/redis-18.19.2/Chart.yaml
+++ b/charts/redis-18.19.2/Chart.yaml
@@ -36,4 +36,4 @@ name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
 - https://github.com/firefliesai/public-helm-charts
-version: 18.19.6
+version: 18.19.7

--- a/charts/redis-18.19.2/values.yaml
+++ b/charts/redis-18.19.2/values.yaml
@@ -2128,7 +2128,7 @@ sysctl:
 imageRegistrySecret:
   ## Enable ExternalSecret creation for registry pull secrets
   ##
-  enabled: true
+  enabled: false
   ## Refresh interval for the external secret
   ##
   refreshInterval: "1h"

--- a/charts/redis-20.0.2/Chart.yaml
+++ b/charts/redis-20.0.2/Chart.yaml
@@ -36,4 +36,4 @@ name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
 - https://github.com/firefliesai/public-helm-charts
-version: 20.0.6
+version: 20.0.7

--- a/charts/redis-20.0.2/values.yaml
+++ b/charts/redis-20.0.2/values.yaml
@@ -2243,7 +2243,7 @@ sysctl:
 imageRegistrySecret:
   ## Enable ExternalSecret creation for registry pull secrets
   ##
-  enabled: true
+  enabled: false
   ## Refresh interval for the external secret
   ##
   refreshInterval: "1h"

--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: redis-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 10.0.3
+version: 10.0.4

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -1172,7 +1172,7 @@ sysctlImage:
 imageRegistrySecret:
   ## Enable ExternalSecret creation for registry pull secrets
   ##
-  enabled: true
+  enabled: false
   ## Refresh interval for the external secret
   ##
   refreshInterval: "1h"


### PR DESCRIPTION
…ets in Redis charts

## What does this PR do?

https://firefliesapp.slack.com/archives/CKD0K54LW/p1759113796241089?thread_ts=1759090904.544029&cid=CKD0K54LW

## Type of change

This pull request is a
- [ ] Feature
- [x] Bugfix
- [x] Enhancement

Which introduces
- [ ] Breaking changes
- [x] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

xxx

## Screenshots (if appropriate)

xxx

## Loom Video (if appropriate)

xxx

## Any Security implications

xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis chart defaults to disable automatic creation of image registry pull secrets via ExternalSecret.
  * Applies across multiple Redis chart variants for consistent behavior.
  * Operators should verify image pull credentials are provisioned by alternative means before deploying or upgrading to avoid pull failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->